### PR TITLE
Fix: Vim-style filter activation with '/' key

### DIFF
--- a/src/ucm/TabGroup.py
+++ b/src/ucm/TabGroup.py
@@ -113,6 +113,13 @@ class TabGroupEdit(Edit, TabGroupNode):
         logging.debug(f"TabGroupEdit.keypress({size},{key}, active={self.is_active})")
 
         if key == "tab":
+            # Deactivate filter when tabbing away
+            if self.is_active:
+                if self.parent_listview and hasattr(self.parent_listview, "deactivate_filter"):
+                    self.parent_listview.deactivate_filter()
+                else:
+                    self.is_active = False
+                    logging.debug("Filter deactivated (no parent)")
             super().focus_next()
             return None
 

--- a/src/ucm/Widgets.py
+++ b/src/ucm/Widgets.py
@@ -293,6 +293,13 @@ class ListView(IdWidget, TabGroupNode):
             if self.view is not None:
                 self.view.pile.set_focus(self.view.filter_pile_pos)
                 self.filter_columns.set_focus(1)
+        elif key == "/":
+            # Activate filter mode
+            logging.debug("/ key pressed - activating filter")
+            if self.view is not None:
+                self.activate_filter()
+                self.view.pile.set_focus(self.view.filter_pile_pos)
+                self.filter_columns.set_focus(1)
 
     def _evaluate(self, filter_string: str, record: dict):
         for key in self.filter_fields:
@@ -311,16 +318,33 @@ class ListView(IdWidget, TabGroupNode):
         self.filter_columns.set_focus(1)
 
     def get_filter_widgets(self):
-        self.filter_edit = TabGroupEdit(align=LEFT)
+        self.filter_edit = TabGroupEdit(align=LEFT, parent_listview=self)
         connect_signal(self.filter_edit, "change", self.filter_action, user_args=[])
+
+        # Store label widget so we can update it when filter is activated
+        self.filter_label = Text("Filter Text:  ", align=RIGHT)
 
         self.filter_columns = Columns(
             [
-                (15, AttrWrap(Text("Filter Text:  ", align=RIGHT), "header", "header")),
+                (15, AttrWrap(self.filter_label, "header", "header")),
                 (35, AttrWrap(self.filter_edit, "filter", "filter")),
             ]
         )
         return self.filter_columns
+
+    def activate_filter(self):
+        """Activate filter mode with visual indicator."""
+        if hasattr(self, "filter_edit") and hasattr(self.filter_edit, "is_active"):
+            self.filter_edit.is_active = True
+            self.filter_label.set_text("Filter [/]:   ")
+            logging.debug("Filter activated")
+
+    def deactivate_filter(self):
+        """Deactivate filter mode and restore normal label."""
+        if hasattr(self, "filter_edit") and hasattr(self.filter_edit, "is_active"):
+            self.filter_edit.is_active = False
+            self.filter_label.set_text("Filter Text:  ")
+            logging.debug("Filter deactivated")
 
     def filter_action(self, _edit_widget, text_input):
         # noinspection PyProtectedMember

--- a/src/ucm/__main__.py
+++ b/src/ucm/__main__.py
@@ -259,6 +259,9 @@ class Application:
             view_key = radio_button.get_label().encode("ascii", "ignore").decode().strip().replace("-", "")
             logger.info(f"switching to view {view_key}")
             self.view_holder._w = self.views[view_key]
+            # Deactivate filter and clear filter text when switching views
+            if hasattr(self.view_holder._w.list_view, "deactivate_filter"):
+                self.view_holder._w.list_view.deactivate_filter()
             self.view_holder._w.list_view.filters_clear()
 
             self.tab_group_manager.add(

--- a/src/ucm/help.txt
+++ b/src/ucm/help.txt
@@ -55,13 +55,17 @@ Switch views using the radio buttons in the header or Tab + arrow keys.
 
 ### Filtering and Sorting
 
-* Type text in filter box to search connections
+* `/` - Activate filter mode (label shows "Filter [/]:" when active)
+* Type text to search connections when filter is active
+* `Esc` - Deactivate filter mode and return to list navigation
 * Filter works on: name, address, user, category (SSH)
 * Filter works on: container ID, name, image (Docker)
 * `Backspace` - Remove filter characters
-* `Ctrl+U` - Clear entire filter
+* `Ctrl+U` - Clear entire filter text
 * `F` - Toggle favorites-only filter (shows [FAV] when active)
 * `r` - Toggle recently used sorting (shows [RECENT] when active)
+
+**Note**: The filter requires explicit activation with `/` to prevent accidental text entry. This allows you to use keyboard shortcuts (f, r, L, etc.) without accidentally typing in the filter box.
 
 ## Mouse Controls
 
@@ -147,9 +151,10 @@ UCM tries `bash` first, then falls back to `sh` if bash isn't available.
 * Use `Tab` to move between UI sections
 
 ### Efficient Filtering
-* Type partial names: "web" finds "webserver1", "webserver2"
+* Press `/` to activate filter mode, then type partial names
+* Example: "web" finds "webserver1", "webserver2"
 * Use categories to group connections
-* Clear filter with `Ctrl+U`
+* Clear filter with `Ctrl+U` or press `Esc` to exit filter mode
 
 ### SSH Config Integration
 * UCM respects `~/.ssh/config` settings
@@ -176,8 +181,9 @@ ucm --log-file ~/ucm.log
 
 ### Quick Connect
 1. Launch UCM
-2. Type filter to find host
-3. Press Enter when filtered to one result
+2. Press `/` to activate filter
+3. Type to find host
+4. Press Enter when filtered to one result
 
 ### Container Access
 1. Switch to Docker view (click or Tab)


### PR DESCRIPTION
## Summary
Fixes the UX bug where filter input could be activated unintentionally when using command keys like `f` (favorite), `r` (recent), or `L` (last connection).

## Changes
- **Explicit filter activation**: Require pressing `/` to activate filter mode (vim-style)
- **Visual indicator**: Label changes to "Filter [/]:" when active
- **Deactivation**: Press `Esc` to deactivate and return to normal navigation
- **Documentation**: Updated help text with filter activation instructions

## How It Works
1. Filter edit widget is inactive by default
2. Press `/` to activate filter mode (visual indicator appears)
3. Type to search connections
4. Press `Esc` to deactivate filter and return to command mode

## Benefits
- Prevents accidental text entry when using command shortcuts
- Clear visual feedback when filter is active
- Familiar vim-style interaction pattern
- User explicitly controls when filter accepts input

## Testing
- ✅ All 66 tests passing
- ✅ Ruff formatting and linting checks passed
- ✅ Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)